### PR TITLE
feat: adding small script to sync EuroPMC data dumps to GCP

### DIFF
--- a/europepmc_data_mover.sh
+++ b/europepmc_data_mover.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Job requirements
+#Submit this script with: sbatch thefilename
+#For more details about each parameter, please check SLURM sbatch documentation https://slurm.schedmd.com/sbatch.html
+
+#SBATCH --time=8:00:00   # walltime
+#SBATCH --ntasks=1   # number of tasks
+#SBATCH --cpus-per-task=16   # number of CPUs Per Task i.e if your code is multi-threaded
+#SBATCH --nodes=1   # number of nodes
+#SBATCH -p datamover   # partition(s)
+#SBATCH --mem=32G   # memory per node
+#SBATCH --mail-type=all
+#SBATCH -J "gcp-uploader"   # job name
+#SBATCH -o "/nfs/production/opentargets/lsf/logs/ot_europmc_gcp_rsync-%j.out"  # job output file
+#SBATCH -e "/nfs/production/opentargets/lsf/logs/ot_europmc_gcp_rsync-%j.err"  # job error file
+target_path='gs://otar025-epmc/ebi_search/raw'
+base_path=/nfs/production/literature/ebi_dump/latest/
+gsutil_path=${HOME}/google-cloud-sdk/bin
+path_ops_baseline="/nfs/production/opentargets"
+path_ops_gcp_service_account="${path_ops_baseline}/gcp-service-account-epmc.json"
+
+# Setting up credentials:
+${gsutil_path}/gcloud auth activate-service-account --key-file=${path_ops_gcp_service_account}
+
+${gsutil_path}/gsutil -m rsync -r -d -x '^(?!.+\.json$)' ${base_path} ${target_path}


### PR DESCRIPTION
## Context

As part of the effort to [date evidence](https://github.com/opentargets/issues/issues/3968), lookup table with publication identifiers and publication date is pulled. Data is got from EuropePMC data dump they generate for EBI search. 

- Source data: `/nfs/production/literature/ebi_dump/latest/`
- Target bucket: `gs://otar025-epmc/ebi_search/raw`
- Running: `sbatch europepmc_data_mover.sh`

**Warning**: the script is not scheduled yet. Needs to be added to a cron job.